### PR TITLE
Issue #9: search tag fix

### DIFF
--- a/src/components/event-search-box.jsx
+++ b/src/components/event-search-box.jsx
@@ -50,7 +50,6 @@ class EventSearchBox extends React.Component {
     RE_PFX = /^!?[0-9]+[.:][0-9.:/]*$/;
     RE_TAG = /^!?[a-zA-Z0-9\-]+$/;
     RE_CODE = /^!?code:[a-zA-Z\-]+$/;
-    // irr-LEVEL3-all-newcomer-no-record
     RE_ASN = /^!?(AS|as)?[0-9]+$/;
 
     _parseSearchInput = (search_text) => {

--- a/src/components/event-search-box.jsx
+++ b/src/components/event-search-box.jsx
@@ -48,8 +48,9 @@ class EventSearchBox extends React.Component {
     };
 
     RE_PFX = /^!?[0-9]+[.:][0-9.:/]*$/;
-    RE_TAG = /^!?[a-zA-Z\-]+$/;
+    RE_TAG = /^!?[a-zA-Z0-9\-]+$/;
     RE_CODE = /^!?code:[a-zA-Z\-]+$/;
+    // irr-LEVEL3-all-newcomer-no-record
     RE_ASN = /^!?(AS|as)?[0-9]+$/;
 
     _parseSearchInput = (search_text) => {
@@ -63,29 +64,29 @@ class EventSearchBox extends React.Component {
 
         let ready = false;
         for(let v of fields){
-            v = v.trim().toLowerCase();
+            v = v.trim();
             if(this.RE_PFX.test(v)){
                 // if this is a prefix
                 prefixes.push(v);
                 ready = true;
             }
 
-            // check if it's a tag
-            if(this.RE_TAG.test(v)){
-                tags.push(v);
-                ready = true;
-            }
-
             // check if it's a code
-            if(this.RE_CODE.test(v)){
+            else if(this.RE_CODE.test(v)){
                 codes.push(v.split(":")[1]);
                 ready = true;
             }
 
             // check if it's an as number
-            if(this.RE_ASN.test(v)){
+            else if(this.RE_ASN.test(v)){
                 v = v.replace(/as/i,"");
                 asns.push(v);
+                ready = true;
+            }
+
+            // check if it's a tag
+            else if(this.RE_TAG.test(v)){
+                tags.push(v);
                 ready = true;
             }
         }


### PR DESCRIPTION
**Status**: Pending deployment, code tested on local
# Changelog
* Fixed Issue https://github.com/InetIntel/grip-ui/issues/9
    * Removed the lowercase transformation of search input
    * Corrected the regex for extracting tags from `/^!?[a-zA-Z\-]+$/;` to `/^!?[a-zA-Z0-9\-]+$/` (This fix takes care of tags which contain numbers)
    * Converted multiple if-else checks to a sequential if-else_if check, as the tag regex is generic, and must not clash with other regex checks.

